### PR TITLE
Update README.md with instruction to create .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Run the following commands on a device with **Docker & Docker Compose**:
 ```sh
 git clone https://github.com/dimgen/homeassistant-vmc-ubbink.git
 cd homeassistant-vmc-ubbink/ubbink-server
+touch .env
 docker-compose up --build -d
 ```
 


### PR DESCRIPTION
This adds the instruction to create an (empty) `.env` file so that the Ubbink Server installation does not fail.