### PR TITLE
Update api.py

### DIFF
--- a/custom_components/vmc_ubbink/api.py
+++ b/custom_components/vmc_ubbink/api.py
@@ -27,3 +27,10 @@ class VMCUbifluxAPI:
             return response.json()
         except requests.RequestException as e:
             return {"error": str(e)}
+
+    def set_bypass_mode(self, mode):
+        try:
+            response = requests.post(f"{self.base_url}/set_mode?mode={mode}", auth=self.auth, timeout=10)
+            return response.json()
+        except requests.RequestException as e:
+            return {"error": str(e)}


### PR DESCRIPTION
adding set_bypass_mode to API
was not discovered in the Home assistant integration, but this should fix that.