### PR TITLE
Implement bypass mode

### DIFF
--- a/custom_components/vmc_ubbink/api.py
+++ b/custom_components/vmc_ubbink/api.py
@@ -30,7 +30,7 @@ class VMCUbifluxAPI:
 
     def set_bypass_mode(self, mode):
         try:
-            response = requests.post(f"{self.base_url}/set_mode?mode={mode}", auth=self.auth, timeout=10)
+            response = requests.post(f"{self.base_url}/set_bypass?mode={mode}", auth=self.auth, timeout=10)
             return response.json()
         except requests.RequestException as e:
             return {"error": str(e)}

--- a/custom_components/vmc_ubbink/direct.py
+++ b/custom_components/vmc_ubbink/direct.py
@@ -38,6 +38,7 @@ _READERS = {
     "exhaust_fan_speed": "get_exhaust_fan_speed",
     "airflow_mode": "get_airflow_mode",
     "bypass_status": "get_bypass_status",
+    "bypass_mode": "get_bypass_mode",
     "filter_status": "get_filter_status",
 }
 
@@ -118,6 +119,5 @@ class DirectClient:
         return err or {"status": f"Airflow rate set to {rate} m³/h"}
 
     def set_bypass_mode(self, mode):
-        # Interface parity with ServerClient; not supported by the vendored register map.
-        _LOGGER.debug("set_bypass_mode(%s) ignored: not supported in direct mode", mode)
-        return {"status": "bypass mode not supported in direct mode"}
+        err = self._set(self._device.set_bypass_mode, mode)
+        return err or {"status": f"Bypass mode set to {mode}"}

--- a/custom_components/vmc_ubbink/select.py
+++ b/custom_components/vmc_ubbink/select.py
@@ -6,10 +6,17 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from .const import DOMAIN
 
 MODES = ["wall_unit", "holiday", "low", "normal", "high", "custom"]
+BYPASS_MODES = ["auto", "closed", "open"]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
     api = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([VMCUbifluxSelect(api, entry.entry_id)], update_before_add=True)
+    async_add_entities(
+        [
+            VMCUbifluxSelect(api, entry.entry_id),
+            VMCUbifluxBypassSelect(api, entry.entry_id),
+        ],
+        update_before_add=True,
+    )
 
 
 class VMCUbifluxSelect(SelectEntity):
@@ -53,6 +60,52 @@ class VMCUbifluxSelect(SelectEntity):
         if data and "error" not in data:
             current_mode = data.get("airflow_mode")
             if current_mode in MODES:
+                self._attr_current_option = current_mode
+                if self._pending_option is not None and current_mode == self._pending_option:
+                    self._pending_option = None
+
+
+class VMCUbifluxBypassSelect(SelectEntity):
+
+    _attr_name = "Bypass Mode"
+    _attr_options = BYPASS_MODES
+
+    def __init__(self, api, entry_id):
+        self.api = api
+        self._entry_id = entry_id
+        self._attr_unique_id = f"vmc_bypass_mode_{entry_id}"
+        self._attr_current_option = None
+        self._pending_option = None  # For optimistic update
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._entry_id)},
+            "name": "VMC Ubiflux",
+            "manufacturer": "Ubbink",
+            "model": "Vigor W325/W400",
+            "entry_type": DeviceEntryType.SERVICE,
+        }
+
+    @property
+    def current_option(self):
+        if self._pending_option is not None:
+            return self._pending_option
+        return self._attr_current_option
+
+    async def async_select_option(self, option: str) -> None:
+        """Select new bypass mode."""
+        self._pending_option = option
+        self.async_write_ha_state()
+        await self.hass.async_add_executor_job(self.api.set_bypass_mode, option)
+        # Do not set self._attr_current_option here, wait for update
+
+    async def async_update(self) -> None:
+        """Asynchronously update state."""
+        data = await self.hass.async_add_executor_job(self.api.get_data)
+        if data and "error" not in data:
+            current_mode = data.get("bypass_mode")
+            if current_mode in BYPASS_MODES:
                 self._attr_current_option = current_mode
                 if self._pending_option is not None and current_mode == self._pending_option:
                     self._pending_option = None

--- a/custom_components/vmc_ubbink/vigor.py
+++ b/custom_components/vmc_ubbink/vigor.py
@@ -48,6 +48,10 @@ _BYPASS_STATUS = {
 _AIRFLOW_MODE_FROM_8001 = {0: "holiday", 1: "low", 2: "normal", 3: "high"}
 _AIRFLOW_MODE_TO_8001 = {"holiday": 0, "low": 1, "normal": 2, "high": 3}
 
+# Bypass mode is holding register 6100: 0=auto, 1=closed, 2=open (Brink UWA2 manual).
+_BYPASS_MODE_FROM_6100 = {0: "auto", 1: "closed", 2: "open"}
+_BYPASS_MODE_TO_6100 = {"auto": 0, "closed": 1, "open": 2}
+
 
 class VigorDevice:
     """Named read/write commands for the Vigor W325/W400 over a pymodbus client."""
@@ -142,6 +146,19 @@ class VigorDevice:
             return "custom"
         value = self._read_holding(8001)[0]
         return _AIRFLOW_MODE_FROM_8001.get(value, f"unknown ({value})")
+
+    def get_bypass_mode(self):
+        # 6100 "Bypass mode": independent of the live position in get_bypass_status (4050).
+        value = self._read_holding(6100)[0]
+        return _BYPASS_MODE_FROM_6100.get(value, f"unknown ({value})")
+
+    def set_bypass_mode(self, mode):
+        if mode not in _BYPASS_MODE_TO_6100:
+            _LOGGER.warning("set_bypass_mode: unsupported mode %r, ignored", mode)
+            return
+        value = _BYPASS_MODE_TO_6100[mode]
+        if self._read_holding(6100)[0] != value:
+            self._write(6100, value)
 
     def set_modbus_mode(self, mode):
         """Switch the control mode (8000). Critical: writes are not applied without it."""

--- a/tests/test_direct_client.py
+++ b/tests/test_direct_client.py
@@ -103,11 +103,20 @@ def test_set_airflow_mode_delegates():
     dev.set_airflow_mode.assert_called_once_with("high")
 
 
-def test_set_bypass_mode_is_noop():
+def test_set_bypass_mode_delegates():
     dev = _device_returning(_FULL)
     client = direct.DirectClient("1.2.3.4", 502, 20, _device=dev, _clock=FakeClock())
-    result = client.set_bypass_mode("auto")
+    result = client.set_bypass_mode("open")
+    dev.set_bypass_mode.assert_called_once_with("open")
     assert "error" not in result
-    assert not dev.method_calls or all(
-        not str(c).startswith("set_bypass_mode") for c in dev.method_calls
-    )
+
+
+def test_set_bypass_mode_invalidates_cache():
+    dev = _device_returning(_FULL)
+    clock = FakeClock()
+    client = direct.DirectClient("1.2.3.4", 502, 20, _device=dev, _clock=clock)
+    client.get_data()
+    assert dev.get_serial_number.call_count == 1
+    client.set_bypass_mode("closed")
+    client.get_data()  # cache invalidated → re-poll even within TTL
+    assert dev.get_serial_number.call_count == 2

--- a/tests/test_vigor.py
+++ b/tests/test_vigor.py
@@ -113,6 +113,45 @@ def test_bypass_status_map():
     assert dev.get_bypass_status() == "unknown (99)"
 
 
+def test_get_bypass_mode_map():
+    client = MagicMock()
+    dev = vigor.VigorDevice(client, slave=20)
+    client.read_holding_registers.return_value = _resp([0])
+    assert dev.get_bypass_mode() == "auto"
+    client.read_holding_registers.return_value = _resp([1])
+    assert dev.get_bypass_mode() == "closed"
+    client.read_holding_registers.return_value = _resp([2])
+    assert dev.get_bypass_mode() == "open"
+    client.read_holding_registers.return_value = _resp([9])
+    assert dev.get_bypass_mode() == "unknown (9)"
+    client.read_holding_registers.assert_called_with(6100, count=1, slave=20)
+
+
+def test_set_bypass_mode_writes_6100_when_changed():
+    client = MagicMock()
+    dev = vigor.VigorDevice(client, slave=20)
+    client.read_holding_registers.return_value = _resp([0])  # currently auto
+    client.write_register.return_value = _resp([], error=False)
+    dev.set_bypass_mode("open")
+    client.write_register.assert_called_once_with(6100, 2, slave=20)
+
+
+def test_set_bypass_mode_skips_write_when_already_set():
+    client = MagicMock()
+    dev = vigor.VigorDevice(client, slave=20)
+    client.read_holding_registers.return_value = _resp([1])  # already closed
+    dev.set_bypass_mode("closed")
+    client.write_register.assert_not_called()
+
+
+def test_set_bypass_mode_ignores_unsupported_mode():
+    client = MagicMock()
+    dev = vigor.VigorDevice(client, slave=20)
+    dev.set_bypass_mode("wall_unit")
+    client.write_register.assert_not_called()
+    client.read_holding_registers.assert_not_called()
+
+
 def test_filter_status():
     client = MagicMock()
     dev = vigor.VigorDevice(client, slave=20)

--- a/ubbink-server/app/main.py
+++ b/ubbink-server/app/main.py
@@ -141,6 +141,29 @@ class ModbusManager:
 
         return response
 
+    def set_bypass_mode(self, mode: str) -> dict:
+        """
+        Sets the bypass mode on the device, respecting throttling and lock,
+        and updates the cache with the newly fetched data.
+        """
+        self._wait_for_access()
+        with self.lock:
+            modbus = ModbusController()
+            if not modbus.connect():
+                return {"error": "Could not connect to device"}
+
+            response = modbus.set_bypass_mode(mode)
+
+            # Fetch fresh data and update cache
+            new_data = modbus.get_data()
+            modbus.disconnect()
+
+        # Update cached data so subsequent calls reflect the new state
+        self.cached_data = new_data
+        self.last_data_access_time = time.monotonic()
+
+        return response
+
 
 # Instantiate a single manager instance for the entire application
 modbus_manager = ModbusManager(
@@ -187,5 +210,16 @@ def set_airflow_rate(request: Request, rate: int):
     logger.info(f"📡 Request from {client_ip}: /set_rate?rate={rate}")
 
     response = modbus_manager.set_airflow_rate(rate)
+    logger.info(f"📤 Response to {client_ip}: {response}")
+    return response
+
+
+@app.post("/set_bypass", dependencies=[Depends(authenticate)])
+@app.get("/set_bypass", dependencies=[Depends(authenticate)])
+def set_bypass_mode(request: Request, mode: str):
+    client_ip = get_client_ip(request)
+    logger.info(f"📡 Request from {client_ip}: /set_bypass?mode={mode}")
+
+    response = modbus_manager.set_bypass_mode(mode)
     logger.info(f"📤 Response to {client_ip}: {response}")
     return response

--- a/ubbink-server/app/modbus_client.py
+++ b/ubbink-server/app/modbus_client.py
@@ -45,6 +45,7 @@ class ModbusController:
             "exhaust_fan_speed": self.device.get_exhaust_fan_speed(),
             "airflow_mode": self.device.get_airflow_mode(),
             "bypass_status": self.device.get_bypass_status(),
+            "bypass_mode": self.device.get_bypass_mode(),
             "filter_status": self.device.get_filter_status(),
         }
 

--- a/ubbink-server/app/pyubbink.py
+++ b/ubbink-server/app/pyubbink.py
@@ -249,6 +249,53 @@ class VigorDevice():
         _log.debug("get_bypass_status: " + result)
         return result
 
+    def get_bypass_mode(self):
+        """
+        Gets the configured bypass mode (holding register 6100, "Bypass mode"
+        per the Brink UWA2 Modbus manual): 0=auto, 1=closed, 2=open.
+
+        Note this differs from get_bypass_status (4050), which reports the live
+        valve position (opening/closing/open/closed).
+        """
+        command = 6100
+        rr = self.client.read_holding_registers(command, 1, unit=self.UNIT)
+        if rr.isError():
+            return self._handle_error(rr, "get_bypass_mode", command)
+
+        _bypass_modes = {0: "auto", 1: "closed", 2: "open"}
+        value = rr.registers[0]
+        result = _bypass_modes.get(value, "unknown (" + str(value) + ")")
+        _log.debug("get_bypass_mode: " + result)
+        return result
+
+    def set_bypass_mode(self, mode):
+        """
+        Sets the bypass mode (holding register 6100): "auto"=0, "closed"=1,
+        "open"=2. 6100 is an independent setting register, so unlike the fan
+        controls it does not require enabling Modbus control (8000).
+        """
+        _bypass_modes = {"auto": 0, "closed": 1, "open": 2}
+        if isinstance(mode, int):
+            mode_value = min(2, max(0, mode))
+        elif mode in _bypass_modes:
+            mode_value = _bypass_modes[mode]
+        else:
+            _log.error("set_bypass_mode: invalid mode " + str(mode))
+            return
+
+        command = 6100
+        rr = self.client.read_holding_registers(command, 1, unit=self.UNIT)
+        if rr.isError():
+            return self._handle_error(rr, "set_bypass_mode.1", command)
+
+        if rr.registers[0] != mode_value:
+            _log.debug("set_bypass_mode: setting bypass mode to " + str(mode_value) + " in range [0-2]")
+            rr = self.client.write_register(command, mode_value, unit=self.UNIT)
+            if rr.isError():
+                return self._handle_error(rr, "set_bypass_mode.2", command)
+        else:
+            _log.debug("set_bypass_mode: bypass mode is already " + str(mode_value))
+
     def get_filter_status(self):
         """ 
         Gets the filter status: dirty/normal


### PR DESCRIPTION
Finish the work started in https://github.com/dimgen/homeassistant-vmc-ubbink/pull/5 and https://github.com/dimgen/homeassistant-vmc-ubbink/pull/6 to add support for bypass mode.

More precisely this PR does:

1. HA UI trigger (a select entity)
2. integration: api.set_bypass_mode → POST /set_bypass: https://github.com/dimgen/homeassistant-vmc-ubbink/pull/6 added the method but pointed it at /set_mode (the AIRFLOW endpoint), I fixed the URL
3. server route: `@app.post("/set_bypass")`
4. `ModbusManager.set_bypass_mode`   (routes go through ModbusManager, not ModbusController)
5. ModbusController.set_bypass_mode was already added in https://github.com/dimgen/homeassistant-vmc-ubbink/pull/5
6. VigorDevice.set_bypass_mode  (the vendored pyubbink.py) from https://github.com/asillye/pyubbink/pull/6