### PR TITLE
ci: run pytest on push and pull_request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+
+      - name: Run tests
+        run: pytest tests/ -v


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow (`.github/workflows/tests.yml`) that installs `requirements-test.txt` and runs the `tests/` suite on Python 3.11 and 3.12, triggered on pushes to `main` and on **every pull request**.

## Why

The repo currently has no CI, so test regressions in incoming PRs go unnoticed. For example, PR #14 (bypass mode) breaks `tests/test_direct_client.py::test_get_data_returns_all_keys` — with this workflow merged to `main`, that failure shows up automatically as a red check on the PR instead of having to be found by hand.

## Verified locally

- On `main`: `24 passed` ✅
- On PR #14's code: `1 failed, 23 passed` ❌ (the workflow correctly catches the regression)

## Notes

- Uses the existing `requirements-test.txt` (pytest + pymodbus 3.x); `tests/conftest.py` already puts `custom_components/vmc_ubbink` on the path, so no extra config is needed.
- For the already-open PR #14, after this is merged to `main`, trigger a re-run via **Update branch** / reopen (fork PRs may need an **Approve and run** click).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VJAg7NkZRxj3dDG9zbsN)_