### PR TITLE
fix: signed conversion for supply and extract temperatures

### DIFF
--- a/custom_components/vmc_ubbink/vigor.py
+++ b/custom_components/vmc_ubbink/vigor.py
@@ -37,6 +37,15 @@ def convert_from_bcd(bcd):
     return decimal
 
 
+def to_signed_16(value):
+    """Interpret a raw 16-bit Modbus register as a signed integer.
+
+    Modbus registers are untyped 16-bit words and pymodbus returns them
+    unsigned (0..65535); temperatures are signed and go negative in winter.
+    """
+    return value - 65536 if value >= 32768 else value
+
+
 _BYPASS_STATUS = {
     0: "initializing",
     1: "opening",
@@ -101,10 +110,10 @@ class VigorDevice:
         return self._read_input(4042)[0]
 
     def get_supply_temperature(self):
-        return self._read_input(4036)[0] / 10.0
+        return to_signed_16(self._read_input(4036)[0]) / 10.0
 
     def get_extract_temperature(self):
-        return self._read_input(4046)[0] / 10.0
+        return to_signed_16(self._read_input(4046)[0]) / 10.0
 
     def get_supply_humidity(self):
         return self._read_input(4037)[0]
@@ -114,11 +123,8 @@ class VigorDevice:
 
     def get_outdoor_temperature(self):
         # 4081 "NTC 1: Air temperature sensor from outside" (Brink UWA2 manual).
-        # Signed, tenths of a degree (outdoor temp goes negative in winter).
-        raw = self._read_input(4081)[0]
-        if raw >= 32768:
-            raw -= 65536
-        return raw / 10.0
+        # Signed, tenths of a degree (temps go negative in winter).
+        return to_signed_16(self._read_input(4081)[0]) / 10.0
 
     def get_supply_fan_speed(self):
         return self._read_input(4034)[0]  # 4034 "Speed supply fan" (RPM)

--- a/tests/test_vigor.py
+++ b/tests/test_vigor.py
@@ -39,6 +39,23 @@ def test_extract_temperature_divides_by_ten():
     client.read_input_registers.assert_called_once_with(4046, count=1, slave=7)
 
 
+def test_supply_temperature_negative_is_signed():
+    client = MagicMock()
+    # 65413 == -123 -> -12.3 °C (supply air after the exchanger can go sub-zero)
+    client.read_input_registers.return_value = _resp([65413])
+    dev = vigor.VigorDevice(client, slave=20)
+    assert dev.get_supply_temperature() == -12.3
+    client.read_input_registers.assert_called_once_with(4036, count=1, slave=20)
+
+
+def test_extract_temperature_negative_is_signed():
+    client = MagicMock()
+    client.read_input_registers.return_value = _resp([65413])
+    dev = vigor.VigorDevice(client, slave=7)
+    assert dev.get_extract_temperature() == -12.3
+    client.read_input_registers.assert_called_once_with(4046, count=1, slave=7)
+
+
 def test_outdoor_temperature_divides_by_ten():
     client = MagicMock()
     client.read_input_registers.return_value = _resp([376])

--- a/ubbink-server/app/pyubbink.py
+++ b/ubbink-server/app/pyubbink.py
@@ -16,6 +16,14 @@ def _convert_from_bcd(bcd):
         place *= 10
     return decimal
 
+def _to_signed_16(value):
+    """ Interpret a raw 16-bit Modbus register as a signed integer.
+
+    Modbus registers are untyped 16-bit words and pymodbus returns them
+    unsigned (0..65535); temperatures are signed and go negative in winter.
+    """
+    return value - 65536 if value >= 32768 else value
+
 class VigorDevice():
     UNIT = 20
 
@@ -140,7 +148,7 @@ class VigorDevice():
         if rr.isError():
             return self._handle_error_int(rr, "get_supply_temperature", command)
 
-        result = rr.registers[0] / 10.0
+        result = _to_signed_16(rr.registers[0]) / 10.0
         _log.debug("get_supply_temperature: " + str(result) + " Celsius")
         return result
 
@@ -153,7 +161,7 @@ class VigorDevice():
         if rr.isError():
             return self._handle_error_int(rr, "get_extract_temperature", command)
 
-        result = rr.registers[0] / 10.0
+        result = _to_signed_16(rr.registers[0]) / 10.0
         _log.debug("get_extract_temperature: " + str(result) + " Celsius")
         return result
 
@@ -194,10 +202,7 @@ class VigorDevice():
         if rr.isError():
             return self._handle_error_int(rr, "get_outdoor_temperature", command)
 
-        raw = rr.registers[0]
-        if raw >= 32768:  # 16-bit signed: outdoor temp can go negative in winter
-            raw -= 65536
-        result = raw / 10.0
+        result = _to_signed_16(rr.registers[0]) / 10.0
         _log.debug("get_outdoor_temperature: " + str(result) + " Celsius")
         return result
 


### PR DESCRIPTION
## What

`get_supply_temperature` (register 4036) and `get_extract_temperature` (4046) divided the raw register by 10 without interpreting it as a signed 16-bit value. A sub-zero reading would wrap to a huge positive number (e.g. raw `65413` → `6541.3 °C` instead of `-12.3 °C`).

This applies the same two's-complement conversion that #13 added for the outdoor temperature, and factors it into a shared helper (`to_signed_16` in `vigor.py`, `_to_signed_16` in `pyubbink.py`) reused by all three temperature getters — so the inline conversion in `get_outdoor_temperature` is now deduplicated too.

## Why

Follow-up to #13, where @blegat noted the other temperatures lacked the fix. Supply air after the heat exchanger is the realistic sub-zero case (bypass open in winter); the conversion is a no-op for positive values, so it's safe for the extract sensor as well.

## Tests

Adds `test_supply_temperature_negative_is_signed` and `test_extract_temperature_negative_is_signed` (raw `65413` → `-12.3 °C`). Full suite: `30 passed` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VJAg7NkZRxj3dDG9zbsN)_