### PR TITLE
Fix Direct mode on pymodbus 3.10+ and give actionable connection errors

### DIFF
--- a/custom_components/vmc_ubbink/config_flow.py
+++ b/custom_components/vmc_ubbink/config_flow.py
@@ -50,16 +50,16 @@ class VMCUbifluxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_direct(self, user_input=None):
         errors = {}
         if user_input is not None:
-            ok = await self.hass.async_add_executor_job(
-                _can_connect,
+            error = await self.hass.async_add_executor_job(
+                _probe,
                 user_input[CONF_HOST],
                 user_input[CONF_PORT],
                 user_input[CONF_SLAVE],
             )
-            if ok:
+            if error is None:
                 data = {CONF_MODE: MODE_DIRECT, **user_input}
                 return self.async_create_entry(title="VMC Ubiflux", data=data)
-            errors["base"] = "cannot_connect"
+            errors["base"] = error
 
         return self.async_show_form(
             step_id="direct",
@@ -78,16 +78,16 @@ class VMCUbifluxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return VMCUbifluxOptionsFlowHandler()
 
 
-def _can_connect(host, port, slave):
-    """Probe by reading serial_number (4010). Runs in the executor."""
+def _probe(host, port, slave):
+    """Probe the gateway/VMC. Runs in the executor.
+
+    Returns None on success, or an error key ("cannot_reach_gateway" /
+    "no_modbus_reply") matching the messages in strings.json.
+    """
     from .direct import DirectClient
 
     client = DirectClient(host, port, slave)
     try:
-        client._ensure_connected()
-        serial = client._device.get_serial_number()
-        return bool(serial)
-    except Exception:  # noqa: BLE001
-        return False
+        return client.probe()
     finally:
         client.close()

--- a/custom_components/vmc_ubbink/direct.py
+++ b/custom_components/vmc_ubbink/direct.py
@@ -44,7 +44,7 @@ _READERS = {
 
 
 class DirectClient:
-    def __init__(self, host, port, slave, *, _device=None, _clock=time.monotonic):
+    def __init__(self, host, port, slave, *, _device=None, _client=None, _clock=time.monotonic):
         self._host = host
         self._port = port
         self._slave = slave
@@ -53,18 +53,52 @@ class DirectClient:
         self._cache = None
         self._cache_ts = 0.0
         if _device is not None:
-            # Test path: inject a ready VigorDevice, no real socket.
+            # Test path: inject a ready VigorDevice (and optionally a fake client).
             self._device = _device
-            self._client = None
+            self._client = _client
         else:
             self._client = ModbusTcpClient(
                 host, port=port, framer=RTU_FRAMER, timeout=10
             )
             self._device = VigorDevice(self._client, slave=slave)
 
+    def connect(self):
+        """Open the socket; return True if connected.
+
+        Lets the config-flow probe tell a gateway that refuses the connection
+        apart from one that connects but never answers Modbus. The injected
+        test device has no real socket, so it is treated as already connected.
+        """
+        if self._client is None:
+            return True
+        return self._client.connect()
+
     def _ensure_connected(self):
         if self._client is not None and not self._client.connected:
             self._client.connect()
+
+    def probe(self):
+        """Config-flow connectivity check.
+
+        Returns None on success, or an error key naming where it failed:
+        - "cannot_reach_gateway": the TCP socket could not be opened
+          (connection refused / timed out / host unreachable) — the gateway is
+          unreachable and the integration never talked to the VMC.
+        - "no_modbus_reply": the socket opened but the VMC did not answer a
+          Modbus read — wrong slave address/wiring/baud, or the gateway is not
+          in transparent RTU mode.
+        """
+        try:
+            reachable = self.connect()
+        except OSError:
+            reachable = False
+        if not reachable:
+            return "cannot_reach_gateway"
+        try:
+            serial = self._device.get_serial_number()
+        except Exception:  # noqa: BLE001 - reached the gateway, Modbus side failed
+            return "no_modbus_reply"
+        return None if serial else "no_modbus_reply"
 
     def close(self):
         if self._client is not None:

--- a/custom_components/vmc_ubbink/strings.json
+++ b/custom_components/vmc_ubbink/strings.json
@@ -28,7 +28,9 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect: no answer from the VMC via the Waveshare gateway."
+      "cannot_connect": "Failed to connect: no answer from the VMC via the Waveshare gateway.",
+      "cannot_reach_gateway": "Could not reach the gateway at this IP and port (connection refused or timed out). Check that the RS485-to-ETH module is powered and reachable on the network, set to TCP Server mode, and listening on this port.",
+      "no_modbus_reply": "Reached the gateway, but the VMC did not answer. Check the Modbus slave address, the RS485 wiring (A→2, B→3, GND→1 on port X15), the serial settings (19200 baud, 8N1), and that the gateway uses transparent/raw RTU mode rather than a Modbus-TCP gateway."
     }
   },
   "options": {

--- a/custom_components/vmc_ubbink/translations/en.json
+++ b/custom_components/vmc_ubbink/translations/en.json
@@ -28,7 +28,9 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect: no answer from the VMC via the Waveshare gateway."
+      "cannot_connect": "Failed to connect: no answer from the VMC via the Waveshare gateway.",
+      "cannot_reach_gateway": "Could not reach the gateway at this IP and port (connection refused or timed out). Check that the RS485-to-ETH module is powered and reachable on the network, set to TCP Server mode, and listening on this port.",
+      "no_modbus_reply": "Reached the gateway, but the VMC did not answer. Check the Modbus slave address, the RS485 wiring (A→2, B→3, GND→1 on port X15), the serial settings (19200 baud, 8N1), and that the gateway uses transparent/raw RTU mode rather than a Modbus-TCP gateway."
     }
   },
   "options": {

--- a/custom_components/vmc_ubbink/vigor.py
+++ b/custom_components/vmc_ubbink/vigor.py
@@ -2,11 +2,14 @@
 
 Line-by-line port of ubbink-server/app/pyubbink.py. Differences from the original
 (which targets pymodbus 2.5.3):
-- kwarg `unit=` -> `slave=` (correct for pymodbus 3.x; pymodbus 4.0 will use `device_id=`);
+- the per-request unit-id keyword is resolved at runtime (see _unit_kwarg): it was
+  `unit=` (<3.0), `slave=` (3.0-3.9), then `device_id=` (3.10+) -- all within our
+  `pymodbus>=3.5,<4.0` pin, so we cannot hard-code one name;
 - `count` is passed as a keyword (it is keyword-only in 3.x);
 - read/write failures raise ModbusError instead of returning "error"/-1, so that
   DirectClient can degrade a single failing register to None.
 """
+import inspect
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,6 +49,24 @@ def to_signed_16(value):
     return value - 65536 if value >= 32768 else value
 
 
+def _unit_kwarg(client):
+    """Resolve pymodbus's per-request unit-id keyword for this client.
+
+    pymodbus renamed it over versions: ``slave=`` (3.0-3.9) was replaced by
+    ``device_id=`` in 3.10, and both fall inside our ``pymodbus>=3.5,<4.0`` pin,
+    so passing the wrong one raises ``TypeError`` and breaks every read/write.
+    Inspect the client's read method and pick the name it accepts, defaulting to
+    the modern ``device_id`` when the signature can't be introspected.
+    """
+    try:
+        params = inspect.signature(client.read_input_registers).parameters
+    except (TypeError, ValueError):
+        return "device_id"
+    if "slave" in params and "device_id" not in params:
+        return "slave"
+    return "device_id"
+
+
 _BYPASS_STATUS = {
     0: "initializing",
     1: "opening",
@@ -68,21 +89,23 @@ class VigorDevice:
     def __init__(self, client, slave=20):
         self.client = client
         self.slave = slave
+        # pymodbus renamed slave= -> device_id= in 3.10; resolve it once.
+        self._unit_kw = _unit_kwarg(client)
 
     def _read_input(self, address, count=1):
-        rr = self.client.read_input_registers(address, count=count, slave=self.slave)
+        rr = self.client.read_input_registers(address, count=count, **{self._unit_kw: self.slave})
         if rr.isError():
             raise ModbusError(f"read_input_registers {address} failed: {rr}")
         return rr.registers
 
     def _read_holding(self, address, count=1):
-        rr = self.client.read_holding_registers(address, count=count, slave=self.slave)
+        rr = self.client.read_holding_registers(address, count=count, **{self._unit_kw: self.slave})
         if rr.isError():
             raise ModbusError(f"read_holding_registers {address} failed: {rr}")
         return rr.registers
 
     def _write(self, address, value):
-        rr = self.client.write_register(address, value, slave=self.slave)
+        rr = self.client.write_register(address, value, **{self._unit_kw: self.slave})
         if rr.isError():
             raise ModbusError(f"write_register {address}={value} failed: {rr}")
 

--- a/tests/test_direct_client.py
+++ b/tests/test_direct_client.py
@@ -151,3 +151,26 @@ def test_probe_no_modbus_reply_when_serial_empty():
     dev.get_serial_number.return_value = ""
     client = direct.DirectClient("1.2.3.4", 502, 20, _device=dev, _clock=FakeClock())
     assert client.probe() == "no_modbus_reply"
+
+
+def test_probe_cannot_reach_gateway_when_connect_raises_oserror():
+    dev = _device_returning(_FULL)
+    fake_client = MagicMock()
+    fake_client.connect.side_effect = OSError("[Errno 111] Connection refused")
+    client = direct.DirectClient(
+        "1.2.3.4", 502, 20, _device=dev, _client=fake_client, _clock=FakeClock()
+    )
+    assert client.probe() == "cannot_reach_gateway"
+    dev.get_serial_number.assert_not_called()
+
+
+def test_probe_success_via_real_client_connect():
+    dev = _device_returning(_FULL)
+    fake_client = MagicMock()
+    fake_client.connect.return_value = True  # exercise the production connect() branch
+    client = direct.DirectClient(
+        "1.2.3.4", 502, 20, _device=dev, _client=fake_client, _clock=FakeClock()
+    )
+    assert client.probe() is None
+    fake_client.connect.assert_called_once()
+    dev.get_serial_number.assert_called_once()

--- a/tests/test_direct_client.py
+++ b/tests/test_direct_client.py
@@ -120,3 +120,34 @@ def test_set_bypass_mode_invalidates_cache():
     client.set_bypass_mode("closed")
     client.get_data()  # cache invalidated → re-poll even within TTL
     assert dev.get_serial_number.call_count == 2
+
+
+def test_probe_success_returns_none():
+    dev = _device_returning(_FULL)
+    client = direct.DirectClient("1.2.3.4", 502, 20, _device=dev, _clock=FakeClock())
+    assert client.probe() is None
+
+
+def test_probe_cannot_reach_gateway_when_socket_refused():
+    dev = _device_returning(_FULL)
+    fake_client = MagicMock()
+    fake_client.connect.return_value = False  # connection refused / timed out
+    client = direct.DirectClient(
+        "1.2.3.4", 502, 20, _device=dev, _client=fake_client, _clock=FakeClock()
+    )
+    assert client.probe() == "cannot_reach_gateway"
+    dev.get_serial_number.assert_not_called()  # never reached the VMC
+
+
+def test_probe_no_modbus_reply_when_read_raises():
+    dev = _device_returning(_FULL)
+    dev.get_serial_number.side_effect = vigor.ModbusError("no reply")
+    client = direct.DirectClient("1.2.3.4", 502, 20, _device=dev, _clock=FakeClock())
+    assert client.probe() == "no_modbus_reply"
+
+
+def test_probe_no_modbus_reply_when_serial_empty():
+    dev = _device_returning(_FULL)
+    dev.get_serial_number.return_value = ""
+    client = direct.DirectClient("1.2.3.4", 502, 20, _device=dev, _clock=FakeClock())
+    assert client.probe() == "no_modbus_reply"

--- a/tests/test_vigor.py
+++ b/tests/test_vigor.py
@@ -1,4 +1,7 @@
+import inspect
 from unittest.mock import MagicMock
+
+import pytest
 
 import vigor
 
@@ -20,7 +23,7 @@ def test_serial_number_bcd_zfill():
     client.read_input_registers.return_value = _resp([0x0012, 0x0034, 0x0056])
     dev = vigor.VigorDevice(client, slave=20)
     assert dev.get_serial_number() == "001200340056"
-    client.read_input_registers.assert_called_once_with(4010, count=3, slave=20)
+    client.read_input_registers.assert_called_once_with(4010, count=3, device_id=20)
 
 
 def test_supply_temperature_divides_by_ten():
@@ -28,7 +31,7 @@ def test_supply_temperature_divides_by_ten():
     client.read_input_registers.return_value = _resp([215])
     dev = vigor.VigorDevice(client, slave=20)
     assert dev.get_supply_temperature() == 21.5
-    client.read_input_registers.assert_called_once_with(4036, count=1, slave=20)
+    client.read_input_registers.assert_called_once_with(4036, count=1, device_id=20)
 
 
 def test_extract_temperature_divides_by_ten():
@@ -36,7 +39,7 @@ def test_extract_temperature_divides_by_ten():
     client.read_input_registers.return_value = _resp([189])
     dev = vigor.VigorDevice(client, slave=7)
     assert dev.get_extract_temperature() == 18.9
-    client.read_input_registers.assert_called_once_with(4046, count=1, slave=7)
+    client.read_input_registers.assert_called_once_with(4046, count=1, device_id=7)
 
 
 def test_supply_temperature_negative_is_signed():
@@ -45,7 +48,7 @@ def test_supply_temperature_negative_is_signed():
     client.read_input_registers.return_value = _resp([65413])
     dev = vigor.VigorDevice(client, slave=20)
     assert dev.get_supply_temperature() == -12.3
-    client.read_input_registers.assert_called_once_with(4036, count=1, slave=20)
+    client.read_input_registers.assert_called_once_with(4036, count=1, device_id=20)
 
 
 def test_extract_temperature_negative_is_signed():
@@ -53,7 +56,7 @@ def test_extract_temperature_negative_is_signed():
     client.read_input_registers.return_value = _resp([65413])
     dev = vigor.VigorDevice(client, slave=7)
     assert dev.get_extract_temperature() == -12.3
-    client.read_input_registers.assert_called_once_with(4046, count=1, slave=7)
+    client.read_input_registers.assert_called_once_with(4046, count=1, device_id=7)
 
 
 def test_outdoor_temperature_divides_by_ten():
@@ -61,7 +64,7 @@ def test_outdoor_temperature_divides_by_ten():
     client.read_input_registers.return_value = _resp([376])
     dev = vigor.VigorDevice(client, slave=20)
     assert dev.get_outdoor_temperature() == 37.6
-    client.read_input_registers.assert_called_once_with(4081, count=1, slave=20)
+    client.read_input_registers.assert_called_once_with(4081, count=1, device_id=20)
 
 
 def test_outdoor_temperature_negative_is_signed():
@@ -70,7 +73,7 @@ def test_outdoor_temperature_negative_is_signed():
     client.read_input_registers.return_value = _resp([65413])
     dev = vigor.VigorDevice(client, slave=20)
     assert dev.get_outdoor_temperature() == -12.3
-    client.read_input_registers.assert_called_once_with(4081, count=1, slave=20)
+    client.read_input_registers.assert_called_once_with(4081, count=1, device_id=20)
 
 
 def test_humidity_passthrough():
@@ -78,7 +81,7 @@ def test_humidity_passthrough():
     client.read_input_registers.return_value = _resp([47])
     dev = vigor.VigorDevice(client, slave=20)
     assert dev.get_supply_humidity() == 47
-    client.read_input_registers.assert_called_once_with(4037, count=1, slave=20)
+    client.read_input_registers.assert_called_once_with(4037, count=1, device_id=20)
 
 
 def test_extract_humidity_register():
@@ -86,7 +89,7 @@ def test_extract_humidity_register():
     client.read_input_registers.return_value = _resp([55])
     dev = vigor.VigorDevice(client, slave=20)
     assert dev.get_extract_humidity() == 55
-    client.read_input_registers.assert_called_once_with(4047, count=1, slave=20)
+    client.read_input_registers.assert_called_once_with(4047, count=1, device_id=20)
 
 
 def test_pressure_and_airflow_registers():
@@ -108,7 +111,7 @@ def test_supply_fan_speed_register():
     client.read_input_registers.return_value = _resp([1238])
     dev = vigor.VigorDevice(client, slave=20)
     assert dev.get_supply_fan_speed() == 1238
-    client.read_input_registers.assert_called_once_with(4034, count=1, slave=20)
+    client.read_input_registers.assert_called_once_with(4034, count=1, device_id=20)
 
 
 def test_exhaust_fan_speed_register():
@@ -116,7 +119,7 @@ def test_exhaust_fan_speed_register():
     client.read_input_registers.return_value = _resp([980])
     dev = vigor.VigorDevice(client, slave=7)
     assert dev.get_exhaust_fan_speed() == 980
-    client.read_input_registers.assert_called_once_with(4044, count=1, slave=7)
+    client.read_input_registers.assert_called_once_with(4044, count=1, device_id=7)
 
 
 def test_bypass_status_map():
@@ -141,7 +144,7 @@ def test_get_bypass_mode_map():
     assert dev.get_bypass_mode() == "open"
     client.read_holding_registers.return_value = _resp([9])
     assert dev.get_bypass_mode() == "unknown (9)"
-    client.read_holding_registers.assert_called_with(6100, count=1, slave=20)
+    client.read_holding_registers.assert_called_with(6100, count=1, device_id=20)
 
 
 def test_set_bypass_mode_writes_6100_when_changed():
@@ -150,7 +153,7 @@ def test_set_bypass_mode_writes_6100_when_changed():
     client.read_holding_registers.return_value = _resp([0])  # currently auto
     client.write_register.return_value = _resp([], error=False)
     dev.set_bypass_mode("open")
-    client.write_register.assert_called_once_with(6100, 2, slave=20)
+    client.write_register.assert_called_once_with(6100, 2, device_id=20)
 
 
 def test_set_bypass_mode_skips_write_when_already_set():
@@ -203,7 +206,7 @@ def test_set_airflow_mode_sets_modbus_mode_then_writes_8001():
     client.read_holding_registers.side_effect = [_resp([1]), _resp([0])]
     client.write_register.return_value = _resp([], error=False)
     dev.set_airflow_mode("high")
-    client.write_register.assert_called_once_with(8001, 3, slave=20)
+    client.write_register.assert_called_once_with(8001, 3, device_id=20)
 
 
 def test_set_airflow_mode_wall_unit_writes_8000_zero():
@@ -212,7 +215,7 @@ def test_set_airflow_mode_wall_unit_writes_8000_zero():
     client.read_holding_registers.return_value = _resp([1])  # 8000 != 0 → write 0
     client.write_register.return_value = _resp([], error=False)
     dev.set_airflow_mode("wall_unit")
-    client.write_register.assert_called_once_with(8000, 0, slave=20)
+    client.write_register.assert_called_once_with(8000, 0, device_id=20)
 
 
 def test_set_custom_airflow_rate_clamps_and_sets_mode_2():
@@ -221,7 +224,7 @@ def test_set_custom_airflow_rate_clamps_and_sets_mode_2():
     client.read_holding_registers.return_value = _resp([2])  # 8000 already 2
     client.write_register.return_value = _resp([], error=False)
     dev.set_custom_airflow_rate(500)
-    client.write_register.assert_called_once_with(8002, 400, slave=20)
+    client.write_register.assert_called_once_with(8002, 400, device_id=20)
 
 
 def test_set_custom_airflow_rate_below_min_writes_zero():
@@ -230,14 +233,13 @@ def test_set_custom_airflow_rate_below_min_writes_zero():
     client.read_holding_registers.return_value = _resp([2])
     client.write_register.return_value = _resp([], error=False)
     dev.set_custom_airflow_rate(10)
-    client.write_register.assert_called_once_with(8002, 0, slave=20)
+    client.write_register.assert_called_once_with(8002, 0, device_id=20)
 
 
 def test_read_error_raises_modbus_error():
     client = MagicMock()
     client.read_input_registers.return_value = _resp([], error=True)
     dev = vigor.VigorDevice(client, slave=20)
-    import pytest
     with pytest.raises(vigor.ModbusError):
         dev.get_supply_temperature()
 
@@ -248,3 +250,47 @@ def test_set_airflow_mode_ignores_unsupported_mode():
     dev.set_airflow_mode("custom")
     client.write_register.assert_not_called()
     client.read_holding_registers.assert_not_called()
+
+
+def test_unit_kwarg_picks_slave_for_old_pymodbus_client():
+    class OldClient:
+        def read_input_registers(self, address, count=1, slave=1):
+            ...
+
+    assert vigor._unit_kwarg(OldClient()) == "slave"
+
+
+def test_unit_kwarg_picks_device_id_for_new_pymodbus_client():
+    class NewClient:
+        def read_input_registers(self, address, count=1, device_id=1):
+            ...
+
+    assert vigor._unit_kwarg(NewClient()) == "device_id"
+
+
+def test_unit_kwarg_defaults_to_device_id_when_unintrospectable():
+    # A bare MagicMock has signature (*args, **kwargs); fall back to the modern name.
+    assert vigor._unit_kwarg(MagicMock()) == "device_id"
+
+
+def test_unit_kwarg_matches_installed_pymodbus_signature():
+    # Regression guard for the slave= -> device_id= rename (pymodbus 3.10): the
+    # resolved keyword must actually exist in the installed client's signature.
+    from pymodbus.client import ModbusTcpClient
+
+    client = ModbusTcpClient("127.0.0.1", port=5020)
+    kw = vigor._unit_kwarg(client)
+    params = inspect.signature(client.read_input_registers).parameters
+    assert kw in params
+
+
+def test_real_client_read_does_not_raise_typeerror_on_unit_kwarg():
+    # End-to-end guard: a real VigorDevice read against a dead port must fail at
+    # the transport layer, never with a TypeError from a wrong unit-id kwarg.
+    from pymodbus.client import ModbusTcpClient
+
+    client = ModbusTcpClient("127.0.0.1", port=5020)  # nothing listening
+    dev = vigor.VigorDevice(client, slave=20)
+    with pytest.raises(Exception) as exc:
+        dev.get_serial_number()
+    assert not isinstance(exc.value, TypeError)


### PR DESCRIPTION
Prompted by the report on #12 (a user hitting a misleading "no answer from the VMC" when the real failure was a refused TCP connection). Investigating it surfaced a second, more serious bug.

## 1. Direct mode was broken on pymodbus ≥ 3.10 (blocker)

`vigor.py` called the pymodbus client with `slave=self.slave`, but pymodbus **renamed that keyword to `device_id=` in 3.10.0** — squarely inside the manifest pin `pymodbus>=3.5.0,<4.0.0`. On any pymodbus 3.10–3.13, every `_read_input` / `_read_holding` / `_write` raised `TypeError`, so Direct mode could never read the device. The existing tests missed it because they mock the client (`MagicMock` accepts any kwarg).

Fix: resolve the unit-id keyword once per `VigorDevice` via `_unit_kwarg()` — inspect the client's read method and use `slave` (pymodbus 3.5–3.9) or `device_id` (3.10+), defaulting to the modern name when unintrospectable. Version-agnostic rather than pinning `<3.10`, since pymodbus is shared with Home Assistant core. Added resolver unit tests plus two **real `ModbusTcpClient`** regression tests that exercise the actual pymodbus signature (the mocked tests can't catch this rename).

## 2. Actionable connection errors in the config flow

The Direct setup step reported one generic error for every failure. It now distinguishes:

- **`cannot_reach_gateway`** — the TCP socket couldn't be opened (connection refused / timed out): check the gateway IP/port and that it's in TCP-Server mode. *(This is exactly the `[Errno 111] Connection refused` case from #12.)*
- **`no_modbus_reply`** — the socket opened but the VMC didn't answer: check the slave address, RS485 wiring, baud (19200 8N1), and that the gateway uses transparent RTU mode.

`DirectClient.probe()` returns the matching key; `strings.json` and `translations/en.json` get the messages. Added `probe()` unit tests for success / refused / OSError / read-failure / empty-serial.

## Validation

- `46 passed` locally (was 39; +7 covering the resolver, the real-pymodbus signature guard, and the new probe branches).
- Independently confirmed on pymodbus 3.13.1 that `read_input_registers(..., slave=20)` raises `TypeError` while `device_id=20` is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VJAg7NkZRxj3dDG9zbsN)_