### PR TITLE
release: bump version to 1.2.0

### DIFF
--- a/custom_components/vmc_ubbink/manifest.json
+++ b/custom_components/vmc_ubbink/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dimgen/homeassistant-vmc-ubbink/issues",
   "requirements": ["pymodbus>=3.5.0,<4.0.0"],
-  "version": "1.1.0"
+  "version": "1.2.0"
 }


### PR DESCRIPTION
Bumps `manifest.json` version `1.1.0` → `1.2.0` ahead of cutting the first tagged release (`v1.2.0`), so HACS users get an update notification — in particular the pymodbus 3.10+ Direct-mode fix from #19.

Highlights since the untagged 1.1.0 state:
- Direct mode (Waveshare RS485-to-ETH) now works on pymodbus 3.10+ (`slave=` → `device_id=`) — #19
- Bypass mode control (#14); outdoor temperature + supply/exhaust fan speed sensors (#13)
- Signed conversion for supply/extract/outdoor temperatures (#17)
- Clearer Direct-setup connection errors (unreachable gateway vs. no Modbus reply) — #19

No code changes beyond the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VJAg7NkZRxj3dDG9zbsN)_