### PR TITLE
ci: add workflow_dispatch release workflow

### DIFF
--- a/.github/release-notes/v1.2.0.md
+++ b/.github/release-notes/v1.2.0.md
@@ -1,0 +1,18 @@
+## VMC Ubbink Ubiflux Vigor — v1.2.0
+
+First tagged release.
+
+### Highlights
+- **Direct connection mode** (Waveshare RS485-to-ETH gateway): Home Assistant talks to the unit over the network — no Docker/server host needed. Choose Direct or Server when adding the integration.
+- **Bypass mode** control (auto / open / closed) as a select entity.
+- **New sensors:** outdoor temperature, supply fan speed (RPM), exhaust fan speed (RPM).
+
+### Fixes
+- Direct mode now works on **pymodbus 3.10+** (the `slave=` → `device_id=` rename); previously every read failed with a `TypeError`.
+- Correct **signed** conversion for supply/extract/outdoor temperatures (sub-zero readings no longer wrap to ~6500 °C).
+- Clearer Direct-setup errors: distinguishes "couldn't reach the gateway" from "reached the gateway but the VMC didn't answer".
+
+### Under the hood
+- CI (pytest on 3.11 / 3.12) plus Hassfest & HACS validation workflows.
+
+**Requires** Home Assistant with pymodbus >= 3.5.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to create and release (e.g. v1.2.0)"
+        required: true
+        default: v1.2.0
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; nothing to do."
+            exit 0
+          fi
+          NOTES=".github/release-notes/${TAG}.md"
+          if [ -f "$NOTES" ]; then
+            gh release create "$TAG" --target "$GITHUB_SHA" --title "$TAG" --notes-file "$NOTES"
+          else
+            gh release create "$TAG" --target "$GITHUB_SHA" --title "$TAG" --generate-notes
+          fi


### PR DESCRIPTION
Adds a manually-triggered `release` workflow so releases can be cut from CI (the repo-scoped GitHub API isn't reachable from this session to create a release directly).

- `.github/workflows/release.yml` — `workflow_dispatch` with a `tag` input; creates the GitHub Release **and its tag** from `main` using the built-in `GITHUB_TOKEN` (`permissions: contents: write`). Reads notes from `.github/release-notes/<tag>.md` when present, else `--generate-notes`. No-ops if the release already exists.
- `.github/release-notes/v1.2.0.md` — curated notes for the first release.

After merge I'll dispatch it with `tag=v1.2.0` to publish the release. Reusable for future versions: drop a `vX.Y.Z.md` notes file and dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VJAg7NkZRxj3dDG9zbsN)_