### PR TITLE
ux(select): stop the confusing no-op when Airflow Mode 'custom' is picked

### DIFF
--- a/custom_components/vmc_ubbink/select.py
+++ b/custom_components/vmc_ubbink/select.py
@@ -1,9 +1,13 @@
+import logging
+
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 MODES = ["wall_unit", "holiday", "low", "normal", "high", "custom"]
 BYPASS_MODES = ["auto", "closed", "open"]
@@ -49,6 +53,16 @@ class VMCUbifluxSelect(SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Select new mode."""
+        if option == "custom":
+            # "custom" is a device state, not a settable mode: the unit enters it
+            # when you set an Airflow Rate (the number entity), which is what makes
+            # airflow_mode read back as "custom". Selecting it here would be a no-op
+            # on the device, so ignore it and keep showing the real current mode.
+            _LOGGER.debug(
+                "Airflow Mode 'custom' is not directly selectable; set the Airflow Rate instead"
+            )
+            self.async_write_ha_state()
+            return
         self._pending_option = option
         self.async_write_ha_state()
         await self.hass.async_add_executor_job(self.api.set_airflow_mode, option)

--- a/custom_components/vmc_ubbink/vigor.py
+++ b/custom_components/vmc_ubbink/vigor.py
@@ -198,8 +198,12 @@ class VigorDevice:
         if mode == "wall_unit":
             self.set_modbus_mode(0)
             return
+        if mode == "custom":
+            # "custom" is not a settable mode: enter it by writing a rate to 8002
+            # (set_custom_airflow_rate), not via 8001. Expected no-op, not an error.
+            _LOGGER.debug("set_airflow_mode('custom') ignored; set an airflow rate instead")
+            return
         if mode not in _AIRFLOW_MODE_TO_8001:
-            # "custom" and other modes are not set via 8001 (custom = set a rate via 8002).
             _LOGGER.warning("set_airflow_mode: unsupported mode %r, ignored", mode)
             return
         mode_value = _AIRFLOW_MODE_TO_8001[mode]


### PR DESCRIPTION
Follow-up to the discussion in #12.

`custom` is a *device state* (control register 8000 == 2), not a settable mode — the unit enters it when you write an airflow rate (the number entity). It only stays in the Airflow Mode select's options so Home Assistant can **display** that state (a select's current option must be one of its options). Selecting it did nothing on the device and logged a scary `unsupported mode 'custom', ignored` warning (which the user in #12 hit).

Changes:
- `select.py` — the Airflow Mode select now intercepts `custom`: it skips the device write and re-renders the real current mode. Works for **both** Direct and Server modes (single point).
- `vigor.py` — the `custom` case drops from a `warning` to a `debug` no-op; a genuinely unknown mode still warns.

No behaviour change for real modes; `46 passed` locally. (`select.py` isn't unit-tested because it imports `homeassistant`, same as the rest of the entity layer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VJAg7NkZRxj3dDG9zbsN)_