### PR TITLE
release: bump version to 1.2.1

### DIFF
--- a/.github/release-notes/v1.2.1.md
+++ b/.github/release-notes/v1.2.1.md
@@ -1,0 +1,8 @@
+## VMC Ubbink Ubiflux Vigor — v1.2.1
+
+Patch release.
+
+### Fixes
+- **Airflow Mode "custom":** selecting `custom` no longer sends a no-op to the unit or logs a spurious `unsupported mode 'custom', ignored` warning. `custom` is a display-only state — enter it by setting the **Airflow Rate**. (#12, #22)
+
+Full end-to-end validation of **Direct mode** (Waveshare RS485-to-ETH) on real hardware landed with this line of work — thanks to the reporters in #12.

--- a/custom_components/vmc_ubbink/manifest.json
+++ b/custom_components/vmc_ubbink/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dimgen/homeassistant-vmc-ubbink/issues",
   "requirements": ["pymodbus>=3.5.0,<4.0.0"],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
Bumps `manifest.json` `1.2.0` → `1.2.1` and adds `.github/release-notes/v1.2.1.md`, to cut a patch release shipping the Airflow Mode **"custom"** UX fix (#22) to HACS users.

No code changes beyond the version string. After merge I'll dispatch the `release` workflow with `tag=v1.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VJAg7NkZRxj3dDG9zbsN)_