### PR TITLE
fix(config_flow): stop pre-filling published credentials

### DIFF
--- a/.github/release-notes/v1.2.2.md
+++ b/.github/release-notes/v1.2.2.md
@@ -1,0 +1,11 @@
+## VMC Ubbink Ubiflux Vigor — v1.2.2
+
+Backward-compatible credential UX update for Server mode.
+
+### Security and compatibility
+- New Server-mode setup no longer pre-fills the published `admin` / `secret` credentials, and the password field is masked.
+- Existing Server-mode entries keep their saved credentials and continue to load unchanged, including legacy installations that still use the published defaults.
+- Switching between Server and Direct mode now retains each mode's host, port, credentials, and slave address instead of discarding the inactive mode's settings.
+- The bundled server, Docker configuration, and existing `.env` behavior are unchanged in this release. Direct-mode runtime behavior is unchanged.
+
+Existing Server-mode users should rotate the published credentials in `ubbink-server/.env` and enter the new values under **Settings → Devices & Services → VMC Ubbink → Configure**, but the update does not force an immediate migration.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ over HTTP. See the server setup below. Existing installs keep working unchanged.
   ```sh
   git clone https://github.com/dimgen/homeassistant-vmc-ubbink.git
   cd homeassistant-vmc-ubbink/ubbink-server
+  # Before first start, edit .env and replace the published username/password.
   docker compose up --build -d
   ```
 
@@ -289,7 +290,7 @@ Also, it seems that you cannot set an airflow lower than the controller's settin
 - Restart Home Assistant after adding the integration.
 - Check the API response manually:
   ```sh
-  curl -u admin:secret http://server-ip:8085/data
+  curl -u '<username>:<password>' http://server-ip:8085/data
   ```
 
 ---
@@ -299,4 +300,3 @@ This project is licensed under the **MIT License**.
 
 ## 👨‍💻 Contributing
 Pull requests are welcome! If you find issues, feel free to open an [issue](https://github.com/dimgen/homeassistant-vmc-ubbink/issues).
-

--- a/custom_components/vmc_ubbink/config_flow.py
+++ b/custom_components/vmc_ubbink/config_flow.py
@@ -1,6 +1,11 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from .const import (
     DOMAIN,
@@ -14,12 +19,17 @@ from .const import (
     CONF_SLAVE,
     DEFAULT_HOST,
     DEFAULT_PORT,
-    DEFAULT_USERNAME,
-    DEFAULT_PASSWORD,
     DEFAULT_TCP_PORT,
     DEFAULT_SLAVE,
 )
 from .options_flow import VMCUbifluxOptionsFlowHandler
+
+PASSWORD_SELECTOR = TextSelector(
+    TextSelectorConfig(
+        type=TextSelectorType.PASSWORD,
+        autocomplete="current-password",
+    )
+)
 
 
 class VMCUbifluxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -41,8 +51,8 @@ class VMCUbifluxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
                     vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-                    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): str,
-                    vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): str,
+                    vol.Required(CONF_USERNAME): str,
+                    vol.Required(CONF_PASSWORD): PASSWORD_SELECTOR,
                 }
             ),
         )

--- a/custom_components/vmc_ubbink/manifest.json
+++ b/custom_components/vmc_ubbink/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dimgen/homeassistant-vmc-ubbink/issues",
   "requirements": ["pymodbus>=3.5.0,<4.0.0"],
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/custom_components/vmc_ubbink/mode_options.py
+++ b/custom_components/vmc_ubbink/mode_options.py
@@ -1,0 +1,69 @@
+_MODE_KEY = "mode"
+_CACHE_PREFIX = "_mode"
+
+
+def _cache_key(mode, key):
+    return f"{_CACHE_PREFIX}_{mode}_{key}"
+
+
+def _active_mode(entry_data, current_options, default_mode):
+    return current_options.get(
+        _MODE_KEY,
+        entry_data.get(_MODE_KEY, default_mode),
+    )
+
+
+def get_mode_value(
+    entry_data,
+    current_options,
+    mode,
+    key,
+    default=None,
+    default_mode="server",
+):
+    """Get a setting previously saved for one connection mode."""
+    cached_key = _cache_key(mode, key)
+    if cached_key in current_options:
+        return current_options[cached_key]
+
+    if _active_mode(entry_data, current_options, default_mode) == mode:
+        if key in current_options:
+            return current_options[key]
+        return entry_data.get(key, default)
+
+    if entry_data.get(_MODE_KEY, default_mode) == mode:
+        return entry_data.get(key, default)
+
+    return default
+
+
+def merge_mode_options(
+    entry_data,
+    current_options,
+    target_mode,
+    user_input,
+    mode_fields,
+    default_mode="server",
+):
+    """Save active values while retaining settings for the other mode."""
+    merged = dict(current_options)
+    previous_mode = _active_mode(entry_data, current_options, default_mode)
+
+    for key in mode_fields.get(previous_mode, ()):
+        value = get_mode_value(
+            entry_data,
+            current_options,
+            previous_mode,
+            key,
+            default_mode=default_mode,
+        )
+        if value is not None:
+            merged[_cache_key(previous_mode, key)] = value
+
+    merged.update(user_input)
+    merged[_MODE_KEY] = target_mode
+    for key in mode_fields[target_mode]:
+        if key in user_input:
+            merged[_cache_key(target_mode, key)] = user_input[key]
+
+    return merged

--- a/custom_components/vmc_ubbink/options_flow.py
+++ b/custom_components/vmc_ubbink/options_flow.py
@@ -1,6 +1,11 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from .const import (
     CONF_MODE,
@@ -13,22 +18,52 @@ from .const import (
     CONF_SLAVE,
     DEFAULT_HOST,
     DEFAULT_PORT,
-    DEFAULT_USERNAME,
-    DEFAULT_PASSWORD,
     DEFAULT_TCP_PORT,
     DEFAULT_SLAVE,
+)
+from .mode_options import get_mode_value, merge_mode_options
+
+MODE_FIELDS = {
+    MODE_SERVER: (CONF_HOST, CONF_PORT, CONF_USERNAME, CONF_PASSWORD),
+    MODE_DIRECT: (CONF_HOST, CONF_PORT, CONF_SLAVE),
+}
+
+PASSWORD_SELECTOR = TextSelector(
+    TextSelectorConfig(
+        type=TextSelectorType.PASSWORD,
+        autocomplete="current-password",
+    )
 )
 
 
 class VMCUbifluxOptionsFlowHandler(config_entries.OptionsFlow):
     # HA sets self.config_entry itself (read-only property); do NOT override __init__.
 
-    def _current(self, key, default):
-        opts = self.config_entry.options
-        data = self.config_entry.data
-        if key in opts:
-            return opts[key]
-        return data.get(key, default)
+    def _mode_value(self, mode, key, default=None):
+        return get_mode_value(
+            self.config_entry.data,
+            self.config_entry.options,
+            mode,
+            key,
+            default,
+            MODE_SERVER,
+        )
+
+    def _required_with_suggested_value(self, mode, key):
+        current = self._mode_value(mode, key)
+        if current is None:
+            return vol.Required(key)
+        return vol.Required(key, description={"suggested_value": current})
+
+    def _merged_options(self, mode, user_input):
+        return merge_mode_options(
+            self.config_entry.data,
+            self.config_entry.options,
+            mode,
+            user_input,
+            MODE_FIELDS,
+            MODE_SERVER,
+        )
 
     async def async_step_init(self, user_input=None):
         # Mode selection menu; default = current mode (legacy entries without CONF_MODE => server).
@@ -40,17 +75,27 @@ class VMCUbifluxOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_server(self, user_input=None):
         if user_input is not None:
             return self.async_create_entry(
-                title="", data={CONF_MODE: MODE_SERVER, **user_input}
+                title="", data=self._merged_options(MODE_SERVER, user_input)
             )
 
         return self.async_show_form(
             step_id="server",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_HOST, default=self._current(CONF_HOST, DEFAULT_HOST)): str,
-                    vol.Required(CONF_PORT, default=self._current(CONF_PORT, DEFAULT_PORT)): int,
-                    vol.Required(CONF_USERNAME, default=self._current(CONF_USERNAME, DEFAULT_USERNAME)): str,
-                    vol.Required(CONF_PASSWORD, default=self._current(CONF_PASSWORD, DEFAULT_PASSWORD)): str,
+                    vol.Required(
+                        CONF_HOST,
+                        default=self._mode_value(MODE_SERVER, CONF_HOST, DEFAULT_HOST),
+                    ): str,
+                    vol.Required(
+                        CONF_PORT,
+                        default=self._mode_value(MODE_SERVER, CONF_PORT, DEFAULT_PORT),
+                    ): int,
+                    self._required_with_suggested_value(
+                        MODE_SERVER, CONF_USERNAME
+                    ): str,
+                    self._required_with_suggested_value(
+                        MODE_SERVER, CONF_PASSWORD
+                    ): PASSWORD_SELECTOR,
                 }
             ),
         )
@@ -58,16 +103,29 @@ class VMCUbifluxOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_direct(self, user_input=None):
         if user_input is not None:
             return self.async_create_entry(
-                title="", data={CONF_MODE: MODE_DIRECT, **user_input}
+                title="", data=self._merged_options(MODE_DIRECT, user_input)
             )
 
         return self.async_show_form(
             step_id="direct",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_HOST, default=self._current(CONF_HOST, DEFAULT_HOST)): str,
-                    vol.Required(CONF_PORT, default=self._current(CONF_PORT, DEFAULT_TCP_PORT)): int,
-                    vol.Required(CONF_SLAVE, default=self._current(CONF_SLAVE, DEFAULT_SLAVE)): int,
+                    vol.Required(
+                        CONF_HOST,
+                        default=self._mode_value(MODE_DIRECT, CONF_HOST, DEFAULT_HOST),
+                    ): str,
+                    vol.Required(
+                        CONF_PORT,
+                        default=self._mode_value(
+                            MODE_DIRECT, CONF_PORT, DEFAULT_TCP_PORT
+                        ),
+                    ): int,
+                    vol.Required(
+                        CONF_SLAVE,
+                        default=self._mode_value(
+                            MODE_DIRECT, CONF_SLAVE, DEFAULT_SLAVE
+                        ),
+                    ): int,
                 }
             ),
         )

--- a/custom_components/vmc_ubbink/strings.json
+++ b/custom_components/vmc_ubbink/strings.json
@@ -19,6 +19,7 @@
       },
       "server": {
         "title": "Server (HTTP)",
+        "description": "Enter the credentials configured in ubbink-server/.env. New setups do not pre-fill the published defaults.",
         "data": {
           "host": "Server host",
           "port": "Server port",
@@ -53,6 +54,7 @@
       },
       "server": {
         "title": "Server (HTTP)",
+        "description": "Enter the credentials configured in ubbink-server/.env. Existing saved credentials are retained when switching modes.",
         "data": {
           "host": "Server host",
           "port": "Server port",

--- a/custom_components/vmc_ubbink/translations/en.json
+++ b/custom_components/vmc_ubbink/translations/en.json
@@ -19,6 +19,7 @@
       },
       "server": {
         "title": "Server (HTTP)",
+        "description": "Enter the credentials configured in ubbink-server/.env. New setups do not pre-fill the published defaults.",
         "data": {
           "host": "Server host",
           "port": "Server port",
@@ -53,6 +54,7 @@
       },
       "server": {
         "title": "Server (HTTP)",
+        "description": "Enter the credentials configured in ubbink-server/.env. Existing saved credentials are retained when switching modes.",
         "data": {
           "host": "Server host",
           "port": "Server port",

--- a/tests/test_build_client_compat.py
+++ b/tests/test_build_client_compat.py
@@ -1,0 +1,99 @@
+import importlib.util
+import sys
+import types
+import uuid
+from pathlib import Path
+
+
+_PACKAGE_DIR = (
+    Path(__file__).resolve().parent.parent / "custom_components" / "vmc_ubbink"
+)
+_INIT_PATH = _PACKAGE_DIR / "__init__.py"
+
+
+def _load_component(monkeypatch):
+    package_name = f"vmc_ubbink_compat_{uuid.uuid4().hex}"
+
+    homeassistant = types.ModuleType("homeassistant")
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    core = types.ModuleType("homeassistant.core")
+    exceptions = types.ModuleType("homeassistant.exceptions")
+    config_entries.ConfigEntry = type("ConfigEntry", (), {})
+    core.HomeAssistant = type("HomeAssistant", (), {})
+    exceptions.ConfigEntryNotReady = type("ConfigEntryNotReady", (Exception,), {})
+    monkeypatch.setitem(sys.modules, "homeassistant", homeassistant)
+    monkeypatch.setitem(sys.modules, "homeassistant.config_entries", config_entries)
+    monkeypatch.setitem(sys.modules, "homeassistant.core", core)
+    monkeypatch.setitem(sys.modules, "homeassistant.exceptions", exceptions)
+
+    class FakeAPI:
+        def __init__(self, host, port, username, password):
+            self.args = (host, port, username, password)
+
+    api = types.ModuleType(f"{package_name}.api")
+    api.VMCUbifluxAPI = FakeAPI
+    monkeypatch.setitem(sys.modules, f"{package_name}.api", api)
+
+    class FakeDirectClient:
+        def __init__(self, host, port, slave):
+            self.args = (host, port, slave)
+
+    direct = types.ModuleType(f"{package_name}.direct")
+    direct.DirectClient = FakeDirectClient
+    monkeypatch.setitem(sys.modules, f"{package_name}.direct", direct)
+
+    spec = importlib.util.spec_from_file_location(
+        package_name,
+        _INIT_PATH,
+        submodule_search_locations=[str(_PACKAGE_DIR)],
+    )
+    component = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, package_name, component)
+    spec.loader.exec_module(component)
+    return component
+
+
+def _entry(data, options=None):
+    return types.SimpleNamespace(data=data, options=options or {})
+
+
+def test_legacy_server_entry_keeps_existing_fallback(monkeypatch):
+    component = _load_component(monkeypatch)
+    client = component.build_client(_entry({"host": "server.local", "port": 8085}))
+    assert client.args == ("server.local", 8085, "admin", "secret")
+
+
+def test_existing_server_entry_keeps_saved_credentials(monkeypatch):
+    component = _load_component(monkeypatch)
+    client = component.build_client(
+        _entry(
+            {
+                "mode": "server",
+                "host": "server.local",
+                "port": 8085,
+                "username": "saved-user",
+                "password": "saved-password",
+            }
+        )
+    )
+    assert client.args == (
+        "server.local",
+        8085,
+        "saved-user",
+        "saved-password",
+    )
+
+
+def test_existing_direct_entry_still_needs_no_credentials(monkeypatch):
+    component = _load_component(monkeypatch)
+    client = component.build_client(
+        _entry(
+            {
+                "mode": "direct",
+                "host": "gateway.local",
+                "port": 502,
+                "slave_id": 20,
+            }
+        )
+    )
+    assert client.args == ("gateway.local", 502, 20)

--- a/tests/test_config_flow_defaults.py
+++ b/tests/test_config_flow_defaults.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+_CONFIG_FLOW = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "vmc_ubbink"
+    / "config_flow.py"
+)
+
+
+def test_new_server_setup_does_not_prefill_credentials():
+    source = _CONFIG_FLOW.read_text()
+    assert "default=DEFAULT_USERNAME" not in source
+    assert "default=DEFAULT_PASSWORD" not in source
+    assert "vol.Required(CONF_USERNAME): str" in source
+    assert "vol.Required(CONF_PASSWORD): PASSWORD_SELECTOR" in source

--- a/tests/test_mode_options.py
+++ b/tests/test_mode_options.py
@@ -1,0 +1,72 @@
+from mode_options import get_mode_value, merge_mode_options
+
+
+MODE_FIELDS = {
+    "server": ("host", "port", "username", "password"),
+    "direct": ("host", "port", "slave_id"),
+}
+
+
+def test_existing_server_entry_keeps_credentials_when_switching_modes():
+    entry_data = {
+        "mode": "server",
+        "host": "server.local",
+        "port": 8085,
+        "username": "admin",
+        "password": "secret",
+    }
+
+    direct_options = merge_mode_options(
+        entry_data,
+        {},
+        "direct",
+        {"host": "gateway.local", "port": 502, "slave_id": 20},
+        MODE_FIELDS,
+    )
+
+    assert get_mode_value(entry_data, direct_options, "server", "host") == "server.local"
+    assert get_mode_value(entry_data, direct_options, "server", "username") == "admin"
+    assert get_mode_value(entry_data, direct_options, "server", "password") == "secret"
+
+    server_input = {
+        key: get_mode_value(entry_data, direct_options, "server", key)
+        for key in MODE_FIELDS["server"]
+    }
+    server_options = merge_mode_options(
+        entry_data,
+        direct_options,
+        "server",
+        server_input,
+        MODE_FIELDS,
+    )
+
+    assert server_options["host"] == "server.local"
+    assert server_options["username"] == "admin"
+    assert server_options["password"] == "secret"
+    assert (
+        get_mode_value(entry_data, server_options, "direct", "host")
+        == "gateway.local"
+    )
+    assert get_mode_value(entry_data, server_options, "direct", "port") == 502
+
+
+def test_new_direct_entry_has_no_server_credential_suggestions():
+    entry_data = {
+        "mode": "direct",
+        "host": "gateway.local",
+        "port": 502,
+        "slave_id": 20,
+    }
+    assert get_mode_value(entry_data, {}, "server", "username") is None
+    assert get_mode_value(entry_data, {}, "server", "password") is None
+
+
+def test_merge_preserves_unrelated_options():
+    merged = merge_mode_options(
+        {"mode": "server"},
+        {"unrelated": True},
+        "direct",
+        {"host": "gateway.local", "port": 502, "slave_id": 20},
+        MODE_FIELDS,
+    )
+    assert merged["unrelated"] is True


### PR DESCRIPTION
## Summary

- leave username and password blank for new Server-mode setup
- render saved passwords with the Home Assistant password selector
- preserve separate Server and Direct settings when switching modes
- prepare the backward-compatible v1.2.2 release notes

## Compatibility

- existing Server entries keep saved credentials and the legacy runtime fallback
- existing Direct entries still require no credentials
- new Direct-to-Server setup receives no admin/secret suggestion
- ubbink-server, Docker configuration, and the existing .env behavior are unchanged

## Verification

- pytest tests/ - 53 passed
- Python compileall
- JSON validation
- git diff --check
- architecture-reviewer: CLEAN
- bug-reviewer: CLEAN
- final-code-reviewer: CLEAN

Follow-up to the review note on hacs/default#8826.