### PR TITLE
Use enum for states

### DIFF
--- a/custom_components/vmc_ubbink/sensor.py
+++ b/custom_components/vmc_ubbink/sensor.py
@@ -80,15 +80,21 @@ SENSOR_TYPES = {
     },
     "airflow_mode": {
         "name": "Airflow Mode",
-        "unit": None,  # just a string
+        "unit": None,
+        "device_class": "enum",
+        "options": ["wall_unit", "custom", "holiday", "low", "normal", "high"],
     },
     "bypass_status": {
         "name": "Bypass Status",
         "unit": None,
+        "device_class": "enum",
+        "options": ["initializing", "opening", "closing", "open", "closed"],
     },
     "filter_status": {
         "name": "Filter Status",
         "unit": None,
+        "device_class": "enum",
+        "options": ["normal", "dirty"],
     },
     "serial_number": {
         "name": "Serial Number",
@@ -130,6 +136,7 @@ class VMCUbifluxSensor(SensorEntity):
         self._attr_native_unit_of_measurement = params["unit"]
         self._attr_device_class = params.get("device_class")
         self._attr_state_class = params.get("state_class")
+        self._attr_options = params.get("options")
 
         # State will be stored in _attr_native_value
         self._attr_native_value = None
@@ -156,4 +163,9 @@ class VMCUbifluxSensor(SensorEntity):
         if not data or "error" in data:
             self._attr_native_value = None
         else:
-            self._attr_native_value = data.get(self._sensor_type, None)
+            value = data.get(self._sensor_type, None)
+            if self._attr_options is not None and value not in self._attr_options:
+                # e.g. "unknown (5)" from an unmapped register: an enum sensor
+                # rejects values outside its options list
+                value = None
+            self._attr_native_value = value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,36 @@
+import enum
 import sys
+import types
 from pathlib import Path
 
 # Import the vmc_ubbink modules standalone (vigor.py / direct.py don't depend on HA),
 # bypassing the package __init__.py (which pulls in homeassistant).
 _PKG = Path(__file__).resolve().parent.parent / "custom_components" / "vmc_ubbink"
 sys.path.insert(0, str(_PKG))
+
+try:
+    import homeassistant  # noqa: F401
+except ImportError:
+    # sensor.py imports homeassistant; stub the minimal surface it uses so the
+    # tests keep running without a homeassistant install.
+    _sensor = types.ModuleType("homeassistant.components.sensor")
+    _sensor.SensorEntity = type("SensorEntity", (), {})
+    _config_entries = types.ModuleType("homeassistant.config_entries")
+    _config_entries.ConfigEntry = type("ConfigEntry", (), {})
+    _core = types.ModuleType("homeassistant.core")
+    _core.HomeAssistant = type("HomeAssistant", (), {})
+    _device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+    _device_registry.DeviceEntryType = enum.Enum("DeviceEntryType", {"SERVICE": "service"})
+    sys.modules["homeassistant"] = types.ModuleType("homeassistant")
+    sys.modules["homeassistant.components"] = types.ModuleType("homeassistant.components")
+    sys.modules["homeassistant.components.sensor"] = _sensor
+    sys.modules["homeassistant.config_entries"] = _config_entries
+    sys.modules["homeassistant.core"] = _core
+    sys.modules["homeassistant.helpers"] = types.ModuleType("homeassistant.helpers")
+    sys.modules["homeassistant.helpers.device_registry"] = _device_registry
+
+# Register the package itself without executing its __init__.py, so sensor.py
+# is importable as vmc_ubbink.sensor and its `from .const import DOMAIN` resolves.
+_pkg_mod = types.ModuleType("vmc_ubbink")
+_pkg_mod.__path__ = [str(_PKG)]
+sys.modules["vmc_ubbink"] = _pkg_mod


### PR DESCRIPTION
I tried doing an automation that happens when the bypass status arrives at a given state but no state where listed by home assistant. This is because it's just a string and not an enum. I switched it to an enum with the values in
https://github.com/dimgen/homeassistant-vmc-ubbink/blob/7b60db38c836ee322513dec923eaa2b308064411/custom_components/vmc_ubbink/vigor.py#L70-L83
If we get something out of the `enum` it will be `None` which gets mapped to `unknown` in Home Assistant.