### PR TITLE
docs(release): note enum sensor states in v1.2.2 notes

### DIFF
--- a/.github/release-notes/v1.2.2.md
+++ b/.github/release-notes/v1.2.2.md
@@ -9,3 +9,6 @@ Backward-compatible credential UX update for Server mode.
 - The bundled server, Docker configuration, and existing `.env` behavior are unchanged in this release. Direct-mode runtime behavior is unchanged.
 
 Existing Server-mode users should rotate the published credentials in `ubbink-server/.env` and enter the new values under **Settings → Devices & Services → VMC Ubbink → Configure**, but the update does not force an immediate migration.
+
+### Sensors
+- Airflow Mode, Bypass Status and Filter Status are now proper `enum` sensors with declared options, so Home Assistant shows translated states and can use them in the UI as enumerations. An unmapped register value (e.g. `unknown (5)`) now reports as unknown instead of an invalid enum state. Thanks @blegat! (#25)


### PR DESCRIPTION
The v1.2.2 release notes were written as part of #24, before #25 landed. This adds the missing entry so the release describes everything it ships.

- Airflow Mode / Bypass Status / Filter Status are now `enum` sensors with declared options; unmapped register values (e.g. `unknown (5)`) report as unknown instead of an invalid enum state. Credits @blegat (#25).

Notes-only change — no code touched. `62 passed` locally at this HEAD.

After merge I'll dispatch the `release` workflow with `tag=v1.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VJAg7NkZRxj3dDG9zbsN)_